### PR TITLE
Remove scripts/ directory

### DIFF
--- a/README.md
+++ b/README.md
@@ -226,7 +226,6 @@ comma-tools/
 │   ├── monitors/             # Real-time monitoring
 │   └── utils/                # Shared utilities
 ├── tests/                    # Test suite
-├── scripts/                  # Shell script wrappers
 └── docs/                     # Documentation
 ```
 

--- a/scripts/fingerprint.sh
+++ b/scripts/fingerprint.sh
@@ -1,3 +1,0 @@
-cd /data/openpilot/selfdrive/debug/
-export PYTHONPATH=/data/openpilot
-python3 get_fingerprint.py 

--- a/scripts/log-monitor.sh
+++ b/scripts/log-monitor.sh
@@ -1,2 +1,0 @@
-cd /data/openpilot/selfdrive/debug/
-./can_printer.py 0 0x7FF > can_output_$(date +%Y%m%d_%H%M%S).log

--- a/scripts/simple-cabana.sh
+++ b/scripts/simple-cabana.sh
@@ -1,2 +1,0 @@
-cd /data/openpilot/tools/cabana/
-./cabana --panda 

--- a/scripts/test-car.sh
+++ b/scripts/test-car.sh
@@ -1,2 +1,0 @@
-cd /data/openpilot
-python3 -m selfdrive.car.tests.test_car_model

--- a/scripts/verbose-logs.sh
+++ b/scripts/verbose-logs.sh
@@ -1,3 +1,0 @@
-cd /data/openpilot/selfdrive/debug/
-export LOG_TIMESTAMPS=1 
-python3 filter_log_message.py --level DEBUG | grep -i safety


### PR DESCRIPTION
## Summary
- Removed shell script wrappers that were convenience wrappers around openpilot tools
- Updated README.md to remove scripts/ from directory structure
- These scripts don't add value to core comma_tools functionality

## Test plan
- [x] Verified scripts/ was only referenced in documentation
- [x] Confirmed no build processes or Python code references the scripts/
- [x] Updated documentation accordingly

🤖 Generated with [Claude Code](https://claude.ai/code)