### PR TITLE
Add public URL support for comma connect downloads

### DIFF
--- a/README.md
+++ b/README.md
@@ -123,33 +123,58 @@ python3 -m comma_tools.monitors.can_bus_check
 
 The connect downloader downloads log files directly from connect.comma.ai with resume capability and idempotent behavior.
 
+**🚀 New: Public URL Support!** No authentication needed for public comma connect URLs - just paste the URL and download instantly.
+
 **From source (recommended):**
 ```bash
 export PYTHONPATH=src
 
-# Download logs using a connect URL
-python3 -m comma_tools.sources.connect.cli --url https://connect.comma.ai/dcb4c2e18426be55/00000008--0696c823fa --logs --cameras
+# Download PUBLIC connect URLs (no authentication required!)
+python3 -m comma_tools.sources.connect.cli --url https://connect.comma.ai/dcb4c2e18426be55/00000008--0696c823fa --logs
 
-# Download using canonical route name
+# Download with multiple file types
+python3 -m comma_tools.sources.connect.cli --url https://connect.comma.ai/dcb4c2e18426be55/00000008--0696c823fa --logs --qlogs --qcameras
+
+# Download using canonical route name (requires authentication)
 python3 -m comma_tools.sources.connect.cli --route dcb4c2e18426be55|2024-04-19--12-33-20 --logs --dest ./my-logs
 
 # Download all file types with custom settings
 python3 -m comma_tools.sources.connect.cli --url https://connect.comma.ai/... --logs --qlogs --cameras --parallel 8 --verbose
 
 # Dry run to see what would be downloaded
-python3 -m comma_tools.sources.connect.cli --route dcb4c2e18426be55|2024-04-19--12-33-20 --logs --dry-run
+python3 -m comma_tools.sources.connect.cli --url https://connect.comma.ai/dcb4c2e18426be55/00000008--0696c823fa --logs --dry-run
 ```
 
 **Or if installed via pip:**
 ```bash
+# Public URLs work without authentication
+comma-connect-dl --url https://connect.comma.ai/dcb4c2e18426be55/00000008--0696c823fa --logs
+
+# Canonical routes require authentication
 comma-connect-dl --route dcb4c2e18426be55|2024-04-19--12-33-20 --logs --dest ./my-logs
 ```
 
-**Authentication:** Requires JWT token via `COMMA_JWT` environment variable or `~/.comma/auth.json` file (created by `openpilot/tools/lib/auth.py`).
+**Authentication:**
+- **Public connect URLs**: No authentication needed! Just paste and download.
+- **Canonical routes**: Requires JWT token via `COMMA_JWT` environment variable or `~/.comma/auth.json` file (created by `openpilot/tools/lib/auth.py`).
 
 **File Layout:** Downloads are organized as `<dest>/<dongle_id>/<YYYY-MM-DD--HH-MM-SS>/<segment>/<filename>` for compatibility with existing analyzers.
 
-**Note:** Log retention is 3 days (1 year with comma prime). Connect URLs are resolved by searching device segments within a configurable time window (default 7 days).
+**Testing Public URLs:**
+```bash
+# Test with a known public URL (no authentication needed)
+export PYTHONPATH=src
+python3 -m comma_tools.sources.connect.cli \
+  --url https://connect.comma.ai/dcb4c2e18426be55/00000008--0696c823fa \
+  --logs --dry-run --verbose
+
+# Expected output:
+# Attempting public access for connect URL...
+# Resolved route: dcb4c2e18426be55|00000008--0696c823fa
+# Would download from route: dcb4c2e18426be55|00000008--0696c823fa
+```
+
+**Note:** Log retention is 3 days (1 year with comma prime). Public connect URLs are resolved directly using openpilot-compatible parsing - no device segment searching required.
 
 ## Dependency Management
 
@@ -197,6 +222,12 @@ black src/ tests/
 
 # Type checking
 mypy src/
+
+# Test public URL support (no authentication needed)
+export PYTHONPATH=src
+python3 -m comma_tools.sources.connect.cli \
+  --url https://connect.comma.ai/dcb4c2e18426be55/00000008--0696c823fa \
+  --logs --dry-run --verbose
 ```
 
 ### Documentation

--- a/src/comma_tools/sources/connect/auth.py
+++ b/src/comma_tools/sources/connect/auth.py
@@ -44,6 +44,21 @@ def load_auth() -> str:
     )
 
 
+def try_load_auth() -> Optional[str]:
+    """
+    Try to load comma API JWT token, returning None if not found.
+
+    This is useful for attempting public access before requiring authentication.
+
+    Returns:
+        JWT token string if found, None otherwise
+    """
+    try:
+        return load_auth()
+    except FileNotFoundError:
+        return None
+
+
 def redact_token(token: str, show_chars: int = 4) -> str:
     """
     Redact JWT token for safe logging.


### PR DESCRIPTION
🚀 New Feature: Download public comma connect URLs without authentication!

Key improvements:
- ✅ Public connect URLs work instantly (no JWT required)
- ✅ Openpilot-compatible URL parsing and API endpoints
- ✅ Graceful fallback to authenticated access when needed
- ✅ Better error messages for public vs private resources

Technical changes:
- Use api.commadotai.com (openpilot-compatible) instead of api.comma.ai
- Parse connect URLs directly to canonical format (dcb4c2e18426be55/slug -> dcb4c2e18426be55|slug)
- Add optional authentication system with try_load_auth()
- Updated CLI to attempt public access first for connect URLs
- Added comprehensive documentation and testing examples

User experience:
Before: Required JWT setup for any comma connect URL After: Just paste public URLs and download instantly!

Example:
  comma-connect-dl --url https://connect.comma.ai/dcb4c2e18426be55/00000008--0696c823fa --logs

🤖 Generated with [Claude Code](https://claude.ai/code)