### PR TITLE
Fix config override parsing per review feedback

### DIFF
--- a/src/comma_tools/api/config.py
+++ b/src/comma_tools/api/config.py
@@ -254,9 +254,7 @@ class ConfigManager:
 
             return tomli.loads(content)
         except ModuleNotFoundError as exc:
-            raise ValueError(
-                "TOML support requires Python 3.11+ or installing 'tomli'."
-            ) from exc
+            raise ValueError("TOML support requires Python 3.11+ or installing 'tomli'.") from exc
         except Exception as exc:
             raise ValueError(f"Invalid TOML in config file {config_file}: {exc}") from exc
 

--- a/tests/api/test_config_monitoring.py
+++ b/tests/api/test_config_monitoring.py
@@ -96,7 +96,7 @@ class TestConfigurationManagement:
         with patch.dict(
             os.environ,
             {
-                "CTS_CORS_ALLOWED_ORIGINS": "[\"https://example.com\", \"https://test.com\"]",
+                "CTS_CORS_ALLOWED_ORIGINS": '["https://example.com", "https://test.com"]',
             },
         ):
             overrides = manager._load_from_environment()


### PR DESCRIPTION
## Summary
- add JSON/TOML file parsing and stronger type coercion for CTS configuration overrides
- support both comma-separated and JSON array formats when loading list values from the environment
- extend configuration monitoring tests to cover the supported list parsing formats

## Testing
- pytest tests/api/test_config_monitoring.py

------
https://chatgpt.com/codex/tasks/task_e_68d94977e4d08331b5054f1d281efe5c