### PR TITLE
Fix nested list env parsing

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -54,11 +54,13 @@ api = [
 test = [
     "pytest>=6.0",
     "pytest-cov",
+    "pytest-asyncio>=0.23",
     "httpx>=0.24.0",
 ]
 dev = [
     "pytest>=6.0",
     "pytest-cov",
+    "pytest-asyncio>=0.23",
     "httpx>=0.24.0",
     "black",
     "flake8",

--- a/tests/api/test_config_monitoring.py
+++ b/tests/api/test_config_monitoring.py
@@ -3,6 +3,7 @@
 import os
 import tempfile
 from pathlib import Path
+from typing import List
 from unittest.mock import MagicMock, patch
 
 import pytest
@@ -105,6 +106,19 @@ class TestConfigurationManagement:
             "https://example.com",
             "https://test.com",
         ]
+
+    def test_environment_variable_nested_list_requires_json(self):
+        """Test: Nested list environment values must be JSON arrays."""
+
+        with pytest.raises(ValueError):
+            ConfigManager._parse_list_value("[1,2],[3,4]", List[List[int]])
+
+    def test_environment_variable_nested_list_json(self):
+        """Test: Nested list environment values parse correctly from JSON arrays."""
+
+        result = ConfigManager._coerce_env_value('[ ["a", "b"], ["c"] ]', List[List[str]])
+
+        assert result == [["a", "b"], ["c"]]
 
     def test_config_validation(self):
         """Test: Invalid configurations raise appropriate errors."""


### PR DESCRIPTION
## Summary
- prevent infinite recursion when parsing nested list environment variables by requiring JSON arrays
- update configuration parsing helpers to detect nested list types and avoid unsafe fallback splitting
- add regression tests for nested list environment values and include pytest-asyncio in optional deps

## Testing
- pytest tests/api/test_config_monitoring.py tests/api/test_runs.py tests/unit

## Notes
- tests depending on local openpilot checkout (e.g., tests/api/test_runs_integration.py::test_run_lifecycle_transitions) still fail without that repository present; see captured log for details. All targeted API/unit suites above pass locally.
