### PR TITLE
Fix: Add OpenPilot vendor dependencies to Docker container

### DIFF
--- a/.github/workflows/container.yml
+++ b/.github/workflows/container.yml
@@ -72,25 +72,50 @@ jobs:
       - name: Test vendor dependencies (PR)
         if: github.event_name == 'pull_request'
         run: |
-          echo "Testing vendor dependencies in built image..."
-          docker run --rm ghcr.io/anteew/comma-tools:pr-${{ github.event.number }} python3 -c "
+          echo "Testing vendor dependencies using actual startup script..."
+
+          # Create a test script that will be run through the startup mechanism
+          cat > test_vendor.py << 'TESTSCRIPT'
+#!/usr/bin/env python3
 import sys
-sys.path.insert(0, '/comma-tools/vendor/openpilot')
-sys.path.insert(0, '/comma-tools/vendor/openpilot/tools')
+import os
+
+# This script will be run AFTER the startup script has injected paths
+# so we're testing the real-world scenario
+
+print("Python path after startup injection:")
+for p in sys.path:
+    if 'vendor' in p:
+        print(f"  - {p}")
+
 try:
     from tools.lib.logreader import LogReader
     print('✓ LogReader import successful')
 except ImportError as e:
     print(f'✗ LogReader import failed: {e}')
-    exit(1)
+    sys.exit(1)
+
 try:
     import cereal
     print('✓ cereal import successful')
 except ImportError as e:
     print(f'✗ cereal import failed: {e}')
-    exit(1)
-print('All vendor dependencies verified!')
-"
+    sys.exit(1)
+
+print('✓ All vendor dependencies verified using startup script!')
+TESTSCRIPT
+
+          # Test using the cli mode which uses the actual startup script
+          docker run --rm -v $(pwd)/test_vendor.py:/test_vendor.py:ro \
+            ghcr.io/anteew/comma-tools:pr-${{ github.event.number }} \
+            cli python3 /test_vendor.py
+
+          # Also test that regular CLI commands work
+          echo "Testing CLI mode functionality..."
+          docker run --rm ghcr.io/anteew/comma-tools:pr-${{ github.event.number }} cli cts ping
+
+          # Clean up test script
+          rm test_vendor.py
 
       - name: Save image to tar (PR)
         if: github.event_name == 'pull_request'

--- a/.github/workflows/container.yml
+++ b/.github/workflows/container.yml
@@ -48,6 +48,9 @@ jobs:
           push: true
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
+          build-args: |
+            OPENPILOT_VERSION=v0.10.0
+            OPENPILOT_COMMIT=c085b8af19438956c1559
           cache-from: type=gha
           cache-to: type=gha,mode=max
 
@@ -60,8 +63,34 @@ jobs:
           load: true
           tags: ghcr.io/anteew/comma-tools:pr-${{ github.event.number }}
           labels: ${{ steps.meta.outputs.labels }}
+          build-args: |
+            OPENPILOT_VERSION=v0.10.0
+            OPENPILOT_COMMIT=c085b8af19438956c1559
           cache-from: type=gha
           cache-to: type=gha,mode=max
+
+      - name: Test vendor dependencies (PR)
+        if: github.event_name == 'pull_request'
+        run: |
+          echo "Testing vendor dependencies in built image..."
+          docker run --rm ghcr.io/anteew/comma-tools:pr-${{ github.event.number }} python3 -c "
+import sys
+sys.path.insert(0, '/comma-tools/vendor/openpilot')
+sys.path.insert(0, '/comma-tools/vendor/openpilot/tools')
+try:
+    from tools.lib.logreader import LogReader
+    print('✓ LogReader import successful')
+except ImportError as e:
+    print(f'✗ LogReader import failed: {e}')
+    exit(1)
+try:
+    import cereal
+    print('✓ cereal import successful')
+except ImportError as e:
+    print(f'✗ cereal import failed: {e}')
+    exit(1)
+print('All vendor dependencies verified!')
+"
 
       - name: Save image to tar (PR)
         if: github.event_name == 'pull_request'

--- a/Dockerfile
+++ b/Dockerfile
@@ -33,8 +33,8 @@ RUN apt-get update && apt-get install -y --no-install-recommends bash ca-certifi
 WORKDIR /comma-tools
 
 # Copy vendored OpenPilot dependencies from fetch stage
-# Only copy the specific files we need to keep image size minimal
-COPY --from=vendor-fetch /tmp/openpilot/tools/lib/logreader.py /comma-tools/vendor/openpilot/tools/lib/
+# Copy entire tools/lib directory as logreader might have dependencies
+COPY --from=vendor-fetch /tmp/openpilot/tools/lib /comma-tools/vendor/openpilot/tools/lib/
 COPY --from=vendor-fetch /tmp/openpilot/cereal /comma-tools/vendor/openpilot/cereal/
 
 # Create __init__.py files for proper Python module structure

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,27 @@
 # syntax=docker/dockerfile:1
+
+# Stage 1: Fetch OpenPilot vendor dependencies
+FROM python:3.12-slim as vendor-fetch
+
+# OpenPilot version configuration (easy to update)
+ARG OPENPILOT_VERSION=v0.10.0
+ARG OPENPILOT_COMMIT=c085b8af19438956c1559
+
+# Install minimal git for sparse checkout
+RUN apt-get update && \
+    apt-get install -y --no-install-recommends git ca-certificates && \
+    rm -rf /var/lib/apt/lists/*
+
+# Use sparse checkout to fetch only required OpenPilot components
+# This minimizes download size and build time
+RUN git clone --no-checkout --filter=blob:none --depth=1 \
+        https://github.com/commaai/openpilot /tmp/openpilot && \
+    cd /tmp/openpilot && \
+    git sparse-checkout init --cone && \
+    git sparse-checkout set tools/lib cereal && \
+    git checkout ${OPENPILOT_COMMIT}
+
+# Stage 2: Main application build
 FROM python:3.12-slim
 
 ENV PYTHONUNBUFFERED=1 \
@@ -9,6 +32,18 @@ RUN apt-get update && apt-get install -y --no-install-recommends bash ca-certifi
 
 WORKDIR /comma-tools
 
+# Copy vendored OpenPilot dependencies from fetch stage
+# Only copy the specific files we need to keep image size minimal
+COPY --from=vendor-fetch /tmp/openpilot/tools/lib/logreader.py /comma-tools/vendor/openpilot/tools/lib/
+COPY --from=vendor-fetch /tmp/openpilot/cereal /comma-tools/vendor/openpilot/cereal/
+
+# Create __init__.py files for proper Python module structure
+RUN touch /comma-tools/vendor/__init__.py && \
+    touch /comma-tools/vendor/openpilot/__init__.py && \
+    touch /comma-tools/vendor/openpilot/tools/__init__.py && \
+    touch /comma-tools/vendor/openpilot/tools/lib/__init__.py
+
+# Copy application code
 COPY . /comma-tools
 
 RUN pip install --no-cache-dir -e ".[api,client]"

--- a/docker/startup.py
+++ b/docker/startup.py
@@ -8,8 +8,16 @@ import urllib.request
 VENDOR_ROOT = "/comma-tools/vendor/openpilot"
 
 def inject_vendor_paths():
+    """Inject vendor paths if they exist, with helpful diagnostics."""
     tools_dir = os.path.join(VENDOR_ROOT, "tools")
     cereal_dir = os.path.join(VENDOR_ROOT, "cereal")
+
+    # Check if vendor dependencies exist
+    vendor_exists = os.path.isdir(VENDOR_ROOT)
+    if not vendor_exists:
+        print(f"Warning: Vendor dependencies not found at {VENDOR_ROOT}", file=sys.stderr)
+        print("OpenPilot-dependent analyzers may not work properly.", file=sys.stderr)
+
     for p in (VENDOR_ROOT, tools_dir, cereal_dir):
         if os.path.isdir(p) and p not in sys.path:
             sys.path.insert(0, p)

--- a/docs/CONTAINER.md
+++ b/docs/CONTAINER.md
@@ -73,14 +73,10 @@ docker run --rm comma-tools-local cli cts ping
 
 ## Known Issues
 
-### 1. Missing OpenPilot Vendor Dependencies (Critical)
-**Issue:** The container references vendor directories that don't exist:
-- `/comma-tools/vendor/openpilot/tools`
-- `/comma-tools/vendor/openpilot/cereal`
+### 1. ~~Missing OpenPilot Vendor Dependencies~~ (FIXED)
+**Previously:** The container was missing OpenPilot vendor dependencies.
 
-**Impact:** OpenPilot-dependent analyzers (like `cruise-control-analyzer`) will fail with import errors.
-
-**Status:** Tracked in [Issue #103](https://github.com/anteew/comma-tools/issues/103)
+**Status:** Fixed via multi-stage Docker build that fetches OpenPilot v0.10.0 dependencies during build time. See [Issue #103](https://github.com/anteew/comma-tools/issues/103) for history.
 
 ### 2. Daemon Mode Host Binding
 **Issue:** The `--host 0.0.0.0` command-line argument in `startup.py` is not processed by the server.
@@ -128,7 +124,7 @@ docker exec -it <container-name> /bin/bash
 - Exposed port: 8080
 - Working directory: `/comma-tools`
 - Entry point: `/usr/local/bin/comma-tools-startup`
-- OpenPilot version: v0.10.0 (commit c085b8af19438956c1559) - currently not included
+- OpenPilot version: v0.10.0 (commit c085b8af19438956c1559) - included via multi-stage build
 
 ## Caching
 Subsequent builds are faster due to Docker layer caching and GitHub Actions cache. Avoid changing pyproject.toml unnecessarily to maximize cache hits.


### PR DESCRIPTION
## Summary
This PR fixes the critical issue where OpenPilot vendor dependencies were missing from the Docker container, causing all OpenPilot-dependent analyzers to fail with import errors.

## Problem
The Docker container's `startup.py` referenced vendor directories that didn't exist:
- `/comma-tools/vendor/openpilot/tools`
- `/comma-tools/vendor/openpilot/cereal`

This meant tools like `cruise-control-analyzer` couldn't function in the containerized environment.

## Solution
Implemented a multi-stage Docker build that:
1. **Fetches OpenPilot dependencies** during build time using sparse checkout
2. **Minimizes size and build time** by only downloading required components
3. **Pins to specific version** (v0.10.0, commit c085b8af19438956c1559) for reproducibility
4. **Adds CI verification** to ensure vendor dependencies are properly included

## Changes
- 🐳 **Dockerfile**: Added multi-stage build with `vendor-fetch` stage
- 🔧 **GitHub Actions**: Added build args for version management and vendor verification test
- 📝 **startup.py**: Added diagnostic messages for missing vendor dependencies
- 📚 **Documentation**: Updated CONTAINER.md to reflect the fix

## Technical Details
The solution uses:
- **Sparse checkout** to fetch only `tools/lib` and `cereal` directories
- **Blob filtering** (`--filter=blob:none`) to skip file history
- **Build args** for easy version updates in the future
- **GitHub Actions cache** to speed up rebuilds

## Testing
The PR includes automated testing in the CI pipeline that verifies:
- LogReader can be imported successfully
- cereal module is available
- Container builds successfully for PRs

## Impact
- ✅ Fixes Issue #103
- ✅ Enables OpenPilot-dependent analyzers in Docker
- ✅ Maintains small container size through selective inclusion
- ✅ Provides clear upgrade path for future OpenPilot versions

## How to Test Locally
```bash
# Build the image
docker build -t comma-tools-test .

# Test vendor dependencies
docker run --rm comma-tools-test python3 -c "from tools.lib.logreader import LogReader; import cereal; print('Vendor deps OK!')"

# Test analyzer functionality
docker run --rm -v $(pwd):/workspace comma-tools-test cli cts cap
```

Fixes #103

🤖 Generated with [Claude Code](https://claude.com/claude-code)