### PR TITLE
URGENT: Fix Docker build failure by removing --depth=1 from git clone

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -13,8 +13,9 @@ RUN apt-get update && \
     rm -rf /var/lib/apt/lists/*
 
 # Use sparse checkout to fetch only required OpenPilot components
-# This minimizes download size and build time
-RUN git clone --no-checkout --filter=blob:none --depth=1 \
+# Note: Cannot use --depth=1 because we need to checkout a specific commit
+# The filter=blob:none still minimizes download by skipping file contents until checkout
+RUN git clone --no-checkout --filter=blob:none \
         https://github.com/commaai/openpilot /tmp/openpilot && \
     cd /tmp/openpilot && \
     git sparse-checkout init --cone && \


### PR DESCRIPTION
## 🚨 Critical Fix for Container Build Failures

This PR fixes the Docker build failures that have been blocking all container workflows since PR #105 was merged.

## The Problem
The Dockerfile was using `git clone --depth=1` (shallow clone) but then trying to checkout a specific older commit (`c085b8af19438956c1559`). This is impossible because `--depth=1` only fetches the latest commit.

**Error message:**
```
error: pathspec 'c085b8af19438956c1559' did not match any file(s) known to git
```

## The Solution
Remove the `--depth=1` flag while keeping `--filter=blob:none` to still minimize download size.

## Impact
- ✅ Fixes all container build failures on main branch
- ✅ Fixes PR build failures (including PR #108)
- ✅ Allows the updated Docker image with vendor dependencies to finally be published to GHCR
- ✅ Users will finally get the working container with OpenPilot dependencies

## Changes
- Removed `--depth=1` from the git clone command in Dockerfile
- Added comment explaining why depth limitation cannot be used with specific commit checkout
- Kept `--filter=blob:none` to minimize network transfer (only downloads needed blobs)

## Timeline of Failures
- PR #105 (vendor dependencies) - Failed to build
- PR #106 (deprecate analyzer) - Failed to build  
- PR #107 (workflow syntax fix) - Failed to build
- PR #108 (test script improvement) - Currently failing to build

**This fix is critical and should be merged ASAP to unblock all container builds.**

## Testing
Once this PR is merged, the container workflow will:
1. Successfully clone OpenPilot repository
2. Checkout the specific commit needed
3. Build and push the image to GHCR
4. All subsequent PRs will have working container builds

🤖 Generated with [Claude Code](https://claude.com/claude-code)